### PR TITLE
capistrano-ec2tag and aws-sdk

### DIFF
--- a/capistrano-ec2tag.gemspec
+++ b/capistrano-ec2tag.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'capistrano-ec2tag'
-  s.version     = '0.0.3'
+  s.version     = '0.0.4'
   s.authors     = ['Douglas Jarquin']
   s.email       = ['douglasjarquin@me.com']
   s.homepage    = 'https://github.com/douglasjarquin/capistrano-ec2tag'
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'capistrano', '>=2.1.0'
-  s.add_dependency 'right_aws'
+  s.add_dependency 'aws-sdk'
 end

--- a/lib/capistrano/ec2tag.rb
+++ b/lib/capistrano/ec2tag.rb
@@ -1,4 +1,4 @@
-require 'right_aws'
+require 'aws-sdk'
 
 unless Capistrano::Configuration.respond_to?(:instance)
   abort 'capistrano/ec2tag requires Capistrano >= 2'
@@ -9,11 +9,12 @@ module Capistrano
     module Tags
 
       def tag(which, *args)
-        @ec2 ||= RightAws::Ec2.new(fetch(:aws_access_key_id), fetch(:aws_secret_access_key), fetch(:aws_params, {}))
+        @ec2 ||= AWS::EC2.new({access_key_id: fetch(:aws_access_key_id), secret_access_key: fetch(:aws_secret_access_key)}.merge! fetch(:aws_params))
 
-        @ec2.describe_instances(:filters => { 'tag-key' => 'deploy', 'tag-value' => "#{which}" }).each do |instance|
-          server(instance[:dns_name].empty? ? instance[:ip_address] : instance[:dns_name], *args) unless instance[:aws_state] != 'running'
-        end
+        @ec2.instances.filter('tag-key','deploy').filter('tag-value', which).each { |instance|
+          server instance.dns_name || instance.ip_address, *args if instance.status == :running
+        }
+
       end
 
     end


### PR DESCRIPTION
This commit will refactor capistrano-ec2tag to use the aws-sdk gem instead. AWS-SDK returns nil instead of an empty string if there is no dns_name for an instance, so I modified the logic accordingly.
