### PR TITLE
Cache instance lists avoid fetch each time

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ server 'web1.example.com', :web
 # new hotness
 tag 'github-staging', :web
 ```
+If you are running capistrano on ec2 and would like to use private
+ip address
+
+```ruby
+set :aws_force_pvt_ip, true
+```
 
 ## License
 

--- a/capistrano-ec2tag.gemspec
+++ b/capistrano-ec2tag.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'capistrano', '>=2.15.5'
-  s.add_dependency 'aws-sdk', '>=1.8.5'
+  s.add_dependency 'aws-sdk', [ '>=1.8.5', '< 2.0' ]
 end

--- a/lib/capistrano/ec2tag.rb
+++ b/lib/capistrano/ec2tag.rb
@@ -12,10 +12,26 @@ module Capistrano
           def tag(which, *args)
             @ec2 ||= AWS::EC2.new({access_key_id: fetch(:aws_access_key_id), secret_access_key: fetch(:aws_secret_access_key)}.merge! fetch(:aws_params, {}))
 
-            @ec2.instances.filter('tag-key', 'deploy').filter('tag-value', which).each do |instance|
-              server instance.ip_address || instance.private_ip_address, *args if instance.status == :running
+            @target_instances = ec2_instances('deploy') unless @target_instances
+
+            if @target_instances[which]
+              @target_instances[which].each do |ip, status|
+                server ip, *args if status == :running
+              end
             end
           end
+
+          def ec2_instances(tag)
+            AWS.memoize do
+              return @ec2.instances.filter('tag-key', tag).inject({}) do |res,instance|
+                tag_name = instance.tags.to_h[tag]
+                res[tag_name] ||= []
+                res[tag_name] << [ instance.private_ip_address, instance.status]
+                res
+              end
+            end
+          end
+
         end
       end
     end


### PR DESCRIPTION
In 100 over  ec2 instances environments, capistrano tag fetching is very slow,
because `tag` method request aws api every time.

This is test result for evaluating on over 100 instances
- original  
  - 50 seconds

```
% time bundle exec cap production notask 
    triggering load callbacks
  * 2015-03-24 18:27:23 18:27:23 == Currently executing `production'
the task `notask' does not exist
bundle exec cap production notask  6.53s user 0.29s system 13% cpu 50.812 total
```
- Only AWS.memozied block version    https://gist.github.com/osamu/ef7da34e01615322fb8b
  -  13 seconds

```
 % time bundle exec cap production notask
    triggering load callbacks
  * 2015-03-24 18:29:24 18:29:24 == Currently executing `production'
the task `notask' does not exist
bundle exec cap production notask  2.28s user 0.24s system 19% cpu 13.278 total
```
- this pull request
  - 2.7 seconds

```
 time bundle exec cap production notask
    triggering load callbacks
  * 2015-03-24 18:31:00 18:31:00 == Currently executing `production'
the task `notask' does not exist
bundle exec cap production notask  1.80s user 0.25s system 68% cpu 2.983 total
```
